### PR TITLE
Upgrade all dependencies to latest versions

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "98aa6396292d57e737a6ef999d4225ca488859d5",
+    "baseline": "f4fc135de213885b8d072203d324976e4aa1f171",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
Updated vcpkg baseline from 98aa6396 to f4fc135d to upgrade all packages:
- curl: upgraded to 8.16.0 (with http2 and openssl features)
- openssl: upgraded to 3.6.0
- nghttp2: upgraded to 1.67.1
- zlib: upgraded to 1.3.1

All dependencies build successfully and the project compiles without errors. Verified functionality with test build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)